### PR TITLE
add hotkeys to restart the stage

### DIFF
--- a/src/lib/Hotkeys.svelte
+++ b/src/lib/Hotkeys.svelte
@@ -1,0 +1,27 @@
+<script lang="ts">
+	import {enableGlobalHotkeys} from '@feltcoop/dealt';
+	import {swallow} from '@feltjs/util/dom.js';
+
+	import {type Hotkey, matchesHotkey} from '$lib/hotkey';
+
+	export let hotkeys: Hotkey[] = [];
+
+	const handleKeydown = (key: string, target: any): boolean => {
+		for (const hotkey of hotkeys) {
+			const matched = matchesHotkey(hotkey, key);
+			if (matched && (!target || enableGlobalHotkeys(target))) {
+				hotkey.action();
+				return true; // handle only the first match
+			}
+		}
+		return false;
+	};
+</script>
+
+<svelte:window
+	on:keydown={(e) => {
+		if (handleKeydown(e.key, e.target)) {
+			swallow(e);
+		}
+	}}
+/>

--- a/src/lib/hotkey.test.ts
+++ b/src/lib/hotkey.test.ts
@@ -1,6 +1,6 @@
 import {test} from 'uvu';
 import * as assert from 'uvu/assert';
-import {noop} from '@feltjs/util';
+import {noop} from '@feltjs/util/function.js';
 
 import {matchesHotkey, type Hotkey} from '$lib/hotkey';
 

--- a/src/lib/hotkey.test.ts
+++ b/src/lib/hotkey.test.ts
@@ -1,0 +1,25 @@
+import {test} from 'uvu';
+import * as assert from 'uvu/assert';
+
+import {matchesHotkey, type Hotkey} from '$lib/hotkey';
+import {noop} from '@feltjs/util';
+
+test('matches a simple pattern', () => {
+	matchesHotkey({match: 'a', action: noop}, 'a');
+});
+
+test('matches comma-separated values', () => {
+	matchesHotkey({match: 'a,b', action: noop}, 'a');
+	matchesHotkey({match: 'a,b', action: noop}, 'b');
+	matchesHotkey({match: 'a,b,c', action: noop}, 'a');
+	matchesHotkey({match: 'a,b,c', action: noop}, 'b');
+	matchesHotkey({match: 'a,b,c', action: noop}, 'c');
+});
+
+test('caches the parsed data', () => {
+	const hotkey: Hotkey = {match: 'a', action: noop};
+	matchesHotkey(hotkey, 'a');
+	assert.ok(hotkey.parsed);
+});
+
+test.run();

--- a/src/lib/hotkey.test.ts
+++ b/src/lib/hotkey.test.ts
@@ -1,8 +1,8 @@
 import {test} from 'uvu';
 import * as assert from 'uvu/assert';
+import {noop} from '@feltjs/util';
 
 import {matchesHotkey, type Hotkey} from '$lib/hotkey';
-import {noop} from '@feltjs/util';
 
 test('matches a simple pattern', () => {
 	matchesHotkey({match: 'a', action: noop}, 'a');

--- a/src/lib/hotkey.ts
+++ b/src/lib/hotkey.ts
@@ -4,7 +4,7 @@ export interface Hotkey {
 	parsed?: ParsedHotkeyMatch[];
 }
 
-// TODO
+// TODO improve, maybe `shift+a,b,ctrl+shift+c`
 export type ParsedHotkeyMatch = string;
 
 /**
@@ -15,10 +15,8 @@ export type ParsedHotkeyMatch = string;
  * @returns
  */
 export const matchesHotkey = (hotkey: Hotkey, key: string): boolean => {
-	// TODO parse `match` from some matching pattern
 	const parsed = parseHotkeyMatch(hotkey);
 	for (const p of parsed) {
-		// TODO improve, maybe `shift+a,b,ctrl+shift+c`
 		if (p === key) {
 			return true;
 		}

--- a/src/lib/hotkey.ts
+++ b/src/lib/hotkey.ts
@@ -1,0 +1,30 @@
+export interface Hotkey {
+	match: string;
+	action: () => void;
+	parsed?: ParsedHotkeyMatch[];
+}
+
+// TODO
+export type ParsedHotkeyMatch = string;
+
+/**
+ * Returns `true` if `key` matches the `hotkey`.
+ * Currently only supports comma separated single keys, `a,b`.
+ * @param hotkey
+ * @param key event.key, see https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/key
+ * @returns
+ */
+export const matchesHotkey = (hotkey: Hotkey, key: string): boolean => {
+	// TODO parse `match` from some matching pattern
+	const parsed = parseHotkeyMatch(hotkey);
+	for (const p of parsed) {
+		// TODO improve, maybe `shift+a,b,ctrl+shift+c`
+		if (p === key) {
+			return true;
+		}
+	}
+	return false;
+};
+
+const parseHotkeyMatch = (hotkey: Hotkey): ParsedHotkeyMatch[] =>
+	hotkey.parsed || (hotkey.parsed = hotkey.match.split(','));

--- a/src/lib/hotkey.ts
+++ b/src/lib/hotkey.ts
@@ -1,10 +1,10 @@
+// TODO improve, maybe `shift+a,b,ctrl+shift+c`
 export interface Hotkey {
 	match: string;
 	action: () => void;
 	parsed?: ParsedHotkeyMatch[];
 }
 
-// TODO improve, maybe `shift+a,b,ctrl+shift+c`
 export type ParsedHotkeyMatch = string;
 
 /**

--- a/src/routes/ControlScene.svelte
+++ b/src/routes/ControlScene.svelte
@@ -22,6 +22,7 @@
 	import ItemLayers from '$routes/ItemLayers.svelte';
 	import ItemDetails from '$routes/ItemDetails.svelte';
 	import SceneDetails from '$routes/SceneDetails.svelte';
+	import Hotkeys from '$lib/Hotkeys.svelte';
 
 	export let pixi = getPixi();
 	export let layout = getLayout();
@@ -122,4 +123,5 @@
 			</Pane>
 		{/if}
 	{/key}
+	<Hotkeys hotkeys={[{match: 'r,g', action: () => stage?.restart()}]} />
 {/if}

--- a/src/routes/ControlScene.svelte
+++ b/src/routes/ControlScene.svelte
@@ -123,5 +123,5 @@
 			</Pane>
 		{/if}
 	{/key}
-	<Hotkeys hotkeys={[{match: 'r,g', action: () => stage?.restart()}]} />
+	<Hotkeys hotkeys={[{match: 'r', action: () => stage?.restart()}]} />
 {/if}

--- a/src/routes/SceneDetails.svelte
+++ b/src/routes/SceneDetails.svelte
@@ -34,7 +34,9 @@
 	<!-- TODO restart stage button -->
 	<div class="row">
 		<button class="flush" on:click={() => stage.destroy()}>destroy stage</button>
-		<button class="flush" on:click={() => stage.restart()}>restart stage</button>
+		<button class="flush" on:click={() => stage.restart()} title="restart stage [r]"
+			>restart stage</button
+		>
 	</div>
 </div>
 


### PR DESCRIPTION
Adds the first pass at a reusable `Hotkeys` component, and makes `r` restart the stage.