### PR TITLE
add `ItemControls`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,9 +9,9 @@
       "version": "0.0.1",
       "license": "Unlicense",
       "devDependencies": {
-        "@feltcoop/dealt": "^0.18.3",
+        "@feltcoop/dealt": "^0.19.0",
         "@feltjs/eslint-config": "^0.2.1",
-        "@feltjs/felt-ui": "^0.50.2",
+        "@feltjs/felt-ui": "^0.51.0",
         "@feltjs/gro": "^0.72.0",
         "@feltjs/util": "^0.7.5",
         "@sveltejs/adapter-static": "^2.0.1",
@@ -452,15 +452,15 @@
       }
     },
     "node_modules/@feltcoop/dealt": {
-      "version": "0.18.3",
-      "resolved": "https://registry.npmjs.org/@feltcoop/dealt/-/dealt-0.18.3.tgz",
-      "integrity": "sha512-V8qCcacWIwJJYzl4YV9Iyhr3Yj6+r8JVJSv3pao5y9OiP0vMlU2OE0TWJJN1OM196OD9vqhJ7JBU0agYNzpr2A==",
+      "version": "0.19.0",
+      "resolved": "https://registry.npmjs.org/@feltcoop/dealt/-/dealt-0.19.0.tgz",
+      "integrity": "sha512-Tqwe0L1GFNOEoBMIBeSRBOUGkZt9E8hhc/JudG6aRzIH2CR9wZmQODUsikZY3llSpln1vm0UrCs5lZmcWiqR6A==",
       "dev": true,
       "engines": {
         "node": ">=18.14"
       },
       "peerDependencies": {
-        "@feltjs/felt-ui": "^0.50.2",
+        "@feltjs/felt-ui": "^0.51.0",
         "@feltjs/util": "^0.7.5",
         "@ryanatkn/collisions": "^3.0.1",
         "pixi.js": "^7.1.2"
@@ -483,15 +483,15 @@
       }
     },
     "node_modules/@feltjs/felt-ui": {
-      "version": "0.50.2",
-      "resolved": "https://registry.npmjs.org/@feltjs/felt-ui/-/felt-ui-0.50.2.tgz",
-      "integrity": "sha512-EucX9ntgSOYW0IjvtLtWwPNIRtvfngZkEp6xnIXbaJSGuYIiGg7SiSC1jBX9HUjm0WEZSZcW9rbvQCaBoJ+WuA==",
+      "version": "0.51.0",
+      "resolved": "https://registry.npmjs.org/@feltjs/felt-ui/-/felt-ui-0.51.0.tgz",
+      "integrity": "sha512-YhBkhi1jgvEjMSTdccftvGRsER1MaDBosCGuxghJNgCMvd0Wf5jZo2teEk6lCTthAmDrujkKjKqwlH9zJXAq/A==",
       "dev": true,
       "dependencies": {
         "@feltjs/util": "^0.7.5"
       },
       "engines": {
-        "node": ">=18.6.0"
+        "node": ">=18.14.0"
       }
     },
     "node_modules/@feltjs/gro": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.1",
       "license": "Unlicense",
       "devDependencies": {
-        "@feltcoop/dealt": "^0.18.2",
+        "@feltcoop/dealt": "^0.18.3",
         "@feltjs/eslint-config": "^0.2.1",
         "@feltjs/felt-ui": "^0.50.2",
         "@feltjs/gro": "^0.72.0",
@@ -452,9 +452,9 @@
       }
     },
     "node_modules/@feltcoop/dealt": {
-      "version": "0.18.2",
-      "resolved": "https://registry.npmjs.org/@feltcoop/dealt/-/dealt-0.18.2.tgz",
-      "integrity": "sha512-D+8ctAriYrjNCNa2nCMd6UH3zQpcNAuachpPoU8S+DmHzwrlBA14HR78ZXi5/rbvAFqam51KZ6pDEP73jSZsEA==",
+      "version": "0.18.3",
+      "resolved": "https://registry.npmjs.org/@feltcoop/dealt/-/dealt-0.18.3.tgz",
+      "integrity": "sha512-V8qCcacWIwJJYzl4YV9Iyhr3Yj6+r8JVJSv3pao5y9OiP0vMlU2OE0TWJJN1OM196OD9vqhJ7JBU0agYNzpr2A==",
       "dev": true,
       "engines": {
         "node": ">=18.14"

--- a/package.json
+++ b/package.json
@@ -26,9 +26,9 @@
     "check:watch": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json --watch"
   },
   "devDependencies": {
-    "@feltcoop/dealt": "^0.18.3",
+    "@feltcoop/dealt": "^0.19.0",
     "@feltjs/eslint-config": "^0.2.1",
-    "@feltjs/felt-ui": "^0.50.2",
+    "@feltjs/felt-ui": "^0.51.0",
     "@feltjs/gro": "^0.72.0",
     "@feltjs/util": "^0.7.5",
     "@sveltejs/adapter-static": "^2.0.1",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "check:watch": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json --watch"
   },
   "devDependencies": {
-    "@feltcoop/dealt": "^0.18.2",
+    "@feltcoop/dealt": "^0.18.3",
     "@feltjs/eslint-config": "^0.2.1",
     "@feltjs/felt-ui": "^0.50.2",
     "@feltjs/gro": "^0.72.0",

--- a/src/routes/ControlScene.svelte
+++ b/src/routes/ControlScene.svelte
@@ -115,9 +115,11 @@
 	let pointer_down: boolean;
 	let pointer_x: number;
 	let pointer_y: number;
+	$: console.log(`pointer_down`, pointer_down);
 	$: if (pointer_down && stage) handle_pointer_down();
 	const handle_pointer_down = () => {
 		const item = stage!.handle_pointer_down(pointer_x, pointer_y);
+		console.log(`handled item`, item);
 		if (item && item !== $item_selection) {
 			console.log(`clicked item`, item);
 			$item_selection = item;

--- a/src/routes/ControlScene.svelte
+++ b/src/routes/ControlScene.svelte
@@ -122,27 +122,6 @@
 			$item_selection = item;
 		}
 	};
-
-	// TODO BLOCK upstream
-	export const to_layout_x = (
-		world_x: number,
-		layout_width: number,
-		viewport_width: number,
-		camera_width: number,
-		camera_x: number,
-	): number =>
-		(world_x - camera_x + camera_width / 2) * (viewport_width / camera_width) +
-		(layout_width - viewport_width) / 2;
-
-	export const to_layout_y = (
-		world_y: number,
-		layout_height: number,
-		viewport_height: number,
-		camera_height: number,
-		camera_y: number,
-	): number =>
-		(world_y - camera_y + camera_height / 2) * (viewport_height / camera_height) +
-		(layout_height - viewport_height) / 2;
 </script>
 
 <svelte:window
@@ -165,13 +144,7 @@
 		/>
 		{#if mode === 'editing'}
 			{#if $item_selection}
-				<ItemControls
-					item={$item_selection}
-					to_layout_x={(world_x) =>
-						to_layout_x(world_x, $layout.width, $viewport.width, $camera.width, $camera.x)}
-					to_layout_y={(world_y) =>
-						to_layout_y(world_y, $layout.height, $viewport.height, $camera.height, $camera.y)}
-				/>
+				<ItemControls item={$item_selection} {stage} />
 			{/if}
 			<Pane bind:height={pane0_height}>
 				<svelte:fragment slot="header">project</svelte:fragment>

--- a/src/routes/ControlScene.svelte
+++ b/src/routes/ControlScene.svelte
@@ -27,6 +27,7 @@
 	import ProjectDetails from '$routes/ProjectDetails.svelte';
 	import ControlledItem from '$routes/ControlledItem.svelte';
 	import {Project} from '$lib/project';
+	import ItemControls from './ItemControls.svelte';
 
 	export let pixi = get_pixi();
 	export let layout = get_layout();
@@ -121,6 +122,27 @@
 			$item_selection = item;
 		}
 	};
+
+	// TODO BLOCK upstream
+	export const to_layout_x = (
+		world_x: number,
+		layout_width: number,
+		viewport_width: number,
+		camera_width: number,
+		camera_x: number,
+	): number =>
+		(world_x - camera_x + camera_width / 2) * (viewport_width / camera_width) +
+		(layout_width - viewport_width) / 2;
+
+	export const to_layout_y = (
+		world_y: number,
+		layout_height: number,
+		viewport_height: number,
+		camera_height: number,
+		camera_y: number,
+	): number =>
+		(world_y - camera_y + camera_height / 2) * (viewport_height / camera_height) +
+		(layout_height - viewport_height) / 2;
 </script>
 
 <svelte:window
@@ -142,6 +164,15 @@
 			bind:pointer_y
 		/>
 		{#if mode === 'editing'}
+			{#if $item_selection}
+				<ItemControls
+					item={$item_selection}
+					to_layout_x={(world_x) =>
+						to_layout_x(world_x, $layout.width, $viewport.width, $camera.width, $camera.x)}
+					to_layout_y={(world_y) =>
+						to_layout_y(world_y, $layout.height, $viewport.height, $camera.height, $camera.y)}
+				/>
+			{/if}
 			<Pane bind:height={pane0_height}>
 				<svelte:fragment slot="header">project</svelte:fragment>
 				<div class="mode-buttons">

--- a/src/routes/ControlScene.svelte
+++ b/src/routes/ControlScene.svelte
@@ -62,6 +62,7 @@
 	const item_selection: Writable<Item | null> = writable(null);
 
 	$: items = stage?.items;
+	$: controlled = stage?.controlled;
 
 	const exit: ExitStage = (outcome) => {
 		console.log(`exit outcome`, outcome);
@@ -143,7 +144,7 @@
 			bind:pointer_y
 		/>
 		{#if mode === 'editing'}
-			{#if $item_selection}
+			{#if $item_selection && !$controlled}
 				<ItemControls item={$item_selection} {stage} />
 			{/if}
 			<Pane bind:height={pane0_height}>

--- a/src/routes/ControlScene.svelte
+++ b/src/routes/ControlScene.svelte
@@ -115,13 +115,10 @@
 	let pointer_down: boolean;
 	let pointer_x: number;
 	let pointer_y: number;
-	$: console.log(`pointer_down`, pointer_down);
 	$: if (pointer_down && stage) handle_pointer_down();
 	const handle_pointer_down = () => {
 		const item = stage!.handle_pointer_down(pointer_x, pointer_y);
-		console.log(`handled item`, item);
 		if (item && item !== $item_selection) {
-			console.log(`clicked item`, item);
 			$item_selection = item;
 		}
 	};

--- a/src/routes/ControlledItem.svelte
+++ b/src/routes/ControlledItem.svelte
@@ -54,6 +54,13 @@
 	};
 </script>
 
+<Hotkeys
+	hotkeys={[
+		{match: '1', action: control_selected},
+		{match: '2', action: release_control},
+		{match: '3', action: swap_back},
+	]}
+/>
 <div class="controlled-item">
 	<div class="info" style:--color={$controlled ? $color && hsl_to_hex_string(...$color) : null}>
 		{#if $controlled}
@@ -67,18 +74,18 @@
 	</div>
 	<div>
 		<button
-			on:click={release_control}
-			disabled={!enable_release_control}
-			title="release control of this {controlled_name} [1]"
-		>
-			release control
-		</button>
-		<button
 			disabled={!enable_control_selected}
 			on:click={control_selected}
-			title="control this {controlled_name} [2]"
+			title="control this {controlled_name} [1]"
 		>
 			control selected
+		</button>
+		<button
+			on:click={release_control}
+			disabled={!enable_release_control}
+			title="release control of this {controlled_name} [2]"
+		>
+			release control
 		</button>
 		<button
 			disabled={!enable_swap_back}
@@ -89,13 +96,6 @@
 		</button>
 	</div>
 </div>
-<Hotkeys
-	hotkeys={[
-		{match: '1', action: release_control},
-		{match: '2', action: control_selected},
-		{match: '3', action: swap_back},
-	]}
-/>
 
 <style>
 	.controlled-item {

--- a/src/routes/ItemControls.svelte
+++ b/src/routes/ItemControls.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import {type Item, to_layout_x, to_layout_y} from '@feltcoop/dealt';
+	import {type Item, to_layout_x, to_layout_y, to_world_x, to_world_y} from '@feltcoop/dealt';
 	import Surface from '@feltjs/felt-ui/Surface.svelte';
 
 	import type {Stage0} from '$routes/stage0';
@@ -36,39 +36,43 @@
 		stop_dragging();
 	};
 
-	let pointer_down: boolean;
-	$: if (!pointer_down) stop_dragging();
+	let pointer_down: boolean | undefined;
+	$: if (pointer_down === false) stop_dragging();
 
-	let dragging_x: number;
-	let dragging_y: number;
+	let dragging_x: number | null = null; // world coordinates
+	let dragging_y: number | null = null; // world coordinates
 
 	const start_dragging = () => {
 		if (dragging) return;
 		dragging = true;
-		dragging_x = pointer_x;
-		dragging_y = pointer_y;
+		dragging_x = null;
+		dragging_y = null;
 	};
 	const stop_dragging = () => {
 		if (!dragging) return;
 		dragging = false;
-		console.log('stop');
 	};
 
 	let pointer_x: number;
 	let pointer_y: number;
-	$: update_pointer(pointer_x, pointer_y);
-	const update_pointer = (x: number, y: number) => {
-		console.log(`x, y`, x, y);
-		const dx = pointer_x - dragging_x;
-		const dy = pointer_y - dragging_y;
-		// TODO BLOCK atomic update?
-		if (dx || dy) {
-			console.log(`dx, dy`, dx, dy);
-			item.x.set(item.$x + dx);
-			item.y.set(item.$y + dy);
+	$: update_pointer(
+		to_world_x(pointer_x, layout_width, viewport_width, camera_width, camera_x),
+		to_world_y(pointer_y, layout_height, viewport_height, camera_height, camera_y),
+	);
+	const update_pointer = (world_x: number, world_y: number) => {
+		if (dragging_x === null) {
+			dragging_x = world_x;
+			dragging_y = world_y;
+		} else {
+			const dx = world_x - dragging_x;
+			const dy = world_y - dragging_y!;
+			if (dx || dy) {
+				$x += dx;
+				$y += dy;
+				dragging_x = world_x;
+				dragging_y = world_y;
+			}
 		}
-		dragging_x = pointer_x;
-		dragging_y = pointer_y;
 	};
 </script>
 

--- a/src/routes/ItemControls.svelte
+++ b/src/routes/ItemControls.svelte
@@ -91,20 +91,23 @@
 		top: 0;
 	}
 
+	/* TODO extract component */
 	.handle {
 		position: relative;
 		left: calc(var(--input_height) / -2);
 		top: calc(var(--input_height) / -2);
 		width: var(--input_height);
 		height: var(--input_height);
-		border-radius: 50%;
+		background-color: var(--tint_light_1);
 		border: 4px double var(--tint_light_4);
+		border-radius: 50%;
 		box-shadow: 0 0 8px 2px rgba(0, 0, 0, 0.4);
 	}
 	.handle:hover {
 		border-color: var(--tint_light_5);
 	}
 	.handle.dragging {
+		background-color: var(--tint_light_2);
 		border-color: var(--tint_light_6);
 		box-shadow: 0 0 8px 2px rgba(0, 0, 0, 0.4) inset;
 	}

--- a/src/routes/ItemControls.svelte
+++ b/src/routes/ItemControls.svelte
@@ -1,0 +1,17 @@
+<script lang="ts">
+	import type {Item} from '@feltcoop/dealt';
+
+	export let item: Item;
+</script>
+
+<div class="item-controls">
+	<!-- TODO handles to set item.x/y -->
+</div>
+
+<style>
+	.item-controls {
+		position: absolute;
+		left: 0;
+		top: 0;
+	}
+</style>

--- a/src/routes/ItemControls.svelte
+++ b/src/routes/ItemControls.svelte
@@ -73,8 +73,7 @@
 </script>
 
 <div class="item-controls" style:transform="translate3d({layout_x}px, {layout_y}px, 0)">
-	<!-- TODO handles to set item.x/y -->
-	<div class="handle pan-control" on:mousedown={mousedown} on:mouseup={mouseup} />
+	<div class="handle" class:dragging on:mousedown={mousedown} on:mouseup={mouseup} />
 </div>
 {#if dragging}
 	<div class="surface-wrapper">
@@ -97,12 +96,14 @@
 		height: var(--input_height);
 		border-radius: 50%;
 		border: 4px double var(--tint_light_4);
+		box-shadow: 0 0 8px 2px rgba(0, 0, 0, 0.4);
 	}
 	.handle:hover {
 		border-color: var(--tint_light_5);
 	}
-	.handle:active {
+	.handle.dragging {
 		border-color: var(--tint_light_6);
+		box-shadow: 0 0 8px 2px rgba(0, 0, 0, 0.4) inset;
 	}
 
 	.surface-wrapper {

--- a/src/routes/ItemControls.svelte
+++ b/src/routes/ItemControls.svelte
@@ -2,10 +2,19 @@
 	import type {Item} from '@feltcoop/dealt';
 
 	export let item: Item;
+	export let to_layout_x: (world_x: number) => number;
+	export let to_layout_y: (world_y: number) => number;
+
+	$: ({x, y} = item);
+
+	$: console.log(`$x,$y`, $x, $y);
+	$: layout_x = to_layout_x($x);
+	$: layout_y = to_layout_y($y);
 </script>
 
-<div class="item-controls">
+<div class="item-controls" style:transform="translate3d({layout_x}px, {layout_y}px, 0)">
 	<!-- TODO handles to set item.x/y -->
+	TODO ADD HANDLES
 </div>
 
 <style>

--- a/src/routes/ItemControls.svelte
+++ b/src/routes/ItemControls.svelte
@@ -20,10 +20,6 @@
 	$: camera_x = $camera.x;
 	$: camera_y = $camera.y;
 
-	$: console.log(`$x,$y`, $x, $y);
-	$: layout_x = to_layout_x($x, layout_width, viewport_width, camera_width, camera_x);
-	$: layout_y = to_layout_y($y, layout_height, viewport_height, camera_height, camera_y);
-
 	let dragging = false;
 
 	const mousedown = (e: MouseEvent) => {
@@ -74,6 +70,9 @@
 			}
 		}
 	};
+
+	$: layout_x = to_layout_x($x, layout_width, viewport_width, camera_width, camera_x);
+	$: layout_y = to_layout_y($y, layout_height, viewport_height, camera_height, camera_y);
 </script>
 
 <div class="item-controls" style:transform="translate3d({layout_x}px, {layout_y}px, 0)">

--- a/src/routes/ItemControls.svelte
+++ b/src/routes/ItemControls.svelte
@@ -1,15 +1,26 @@
 <script lang="ts">
-	import type {Item} from '@feltcoop/dealt';
+	import {type Item, to_layout_x, to_layout_y} from '@feltcoop/dealt';
+
+	import type {Stage0} from '$routes/stage0';
 
 	export let item: Item;
-	export let to_layout_x: (world_x: number) => number;
-	export let to_layout_y: (world_y: number) => number;
+	export let stage: Stage0;
 
 	$: ({x, y} = item);
+	$: ({layout, viewport, camera} = stage);
+
+	$: layout_width = $layout.width;
+	$: layout_height = $layout.height;
+	$: viewport_width = $viewport.width;
+	$: viewport_height = $viewport.height;
+	$: camera_width = $camera.width;
+	$: camera_height = $camera.height;
+	$: camera_x = $camera.x;
+	$: camera_y = $camera.y;
 
 	$: console.log(`$x,$y`, $x, $y);
-	$: layout_x = to_layout_x($x);
-	$: layout_y = to_layout_y($y);
+	$: layout_x = to_layout_x($x, layout_width, viewport_width, camera_width, camera_x);
+	$: layout_y = to_layout_y($y, layout_height, viewport_height, camera_height, camera_y);
 </script>
 
 <div class="item-controls" style:transform="translate3d({layout_x}px, {layout_y}px, 0)">

--- a/src/routes/ItemLayers.svelte
+++ b/src/routes/ItemLayers.svelte
@@ -13,7 +13,7 @@
 	$: ({controlled} = stage);
 
 	// TODO is janky --s for this initial data, what would be better than this for users?
-	const toInitialItemData = (item: Item | null): ItemData | null => {
+	const to_initial_item_data = (item: Item | null): ItemData | null => {
 		if (!item) return null;
 		const data = item.to_data();
 		if (!data) return null;
@@ -24,7 +24,7 @@
 	};
 
 	const create = (): void => {
-		const item = new Item(stage.collisions, toInitialItemData($item_selection));
+		const item = new Item(stage.collisions, to_initial_item_data($item_selection));
 		stage.add_item(item);
 		$item_selection = item;
 	};

--- a/src/routes/stage0.ts
+++ b/src/routes/stage0.ts
@@ -86,6 +86,7 @@ export class Stage0 extends Stage {
 
 		// create the bounds
 		items.push({
+			tags: ['bounds'],
 			type: 'polygon',
 			x: 0,
 			y: 0,
@@ -99,11 +100,11 @@ export class Stage0 extends Stage {
 			ghostly: true,
 			scale_x: WORLD_SIZE,
 			scale_y: WORLD_SIZE,
-			tags: ['bounds'],
 		});
 
 		// create the target
 		items.push({
+			tags: ['target'],
 			type: 'circle',
 			x: 230,
 			y: 15,
@@ -111,11 +112,11 @@ export class Stage0 extends Stage {
 			color: COLOR_EXIT,
 			speed: 0,
 			strength: 100_000_000,
-			tags: ['target'],
 		});
 
 		// create the rabbit
 		items.push({
+			tags: ['rabbit'],
 			type: 'circle',
 			x: 310,
 			y: -10,
@@ -123,13 +124,12 @@ export class Stage0 extends Stage {
 			color: COLOR_EXIT,
 			speed: (SPEED_SLOW / 2) * 1.01, // unfair D:
 			strength: 1_000_000_000,
-			tags: ['rabbit'],
 			text: '🐰',
 			font_size: 36,
 		});
 		items.push({
-			type: 'circle',
 			tags: ['rabbit_message'],
+			type: 'circle',
 			text: '',
 			font_size: 24,
 			text_fill: hsl_to_hex_string(...COLOR_ROOTED),
@@ -171,15 +171,9 @@ export class Stage0 extends Stage {
 			speed: 0.007,
 		});
 
-		console.log(`create_initial_data`, data);
-
-		return data;
-	}
-
-	// TODO not calling `setup` first is error-prone
-	override async setup(): Promise<void> {
 		// TODO should be a point?
-		this.pointer = new Item<CircleBody>(this.collisions, {
+		items.push({
+			tags: ['pointer'],
 			type: 'circle',
 			x: undefined,
 			y: undefined,
@@ -187,8 +181,14 @@ export class Stage0 extends Stage {
 			invisible: true,
 			ghostly: true,
 		});
-		this.add_item(this.pointer);
 
+		console.log(`create_initial_data`, data);
+
+		return data;
+	}
+
+	// TODO not calling `setup` first is error-prone
+	override async setup(): Promise<void> {
 		// TODO do this better, maybe with `tags` automatically, same with `bounds`
 		for (const item of this.item_by_id.values()) {
 			if (item.$tags?.includes('bounds')) {
@@ -199,6 +199,8 @@ export class Stage0 extends Stage {
 				this.rabbit = item as Item<CircleBody>;
 			} else if (item.$tags?.includes('rabbit_message')) {
 				this.rabbit_message = item as Item<CircleBody>;
+			} else if (item.$tags?.includes('pointer')) {
+				this.pointer = item as Item<CircleBody>;
 			}
 		}
 		this.swap_control(this.$controlled, true);


### PR DESCRIPTION
followup to #13

Adds `ItemControls` that are shown in edit mode when an item is selected. They're displayed on the item so it's direct manipulation.

next:

- shift+click+drag to pan
- make `ItemControls` handle circle radius
- refactor `ItemControls`, extract handle components
- fix controller moving the selected item (needs to be disabled, or set to the camera?)
- make `ItemControls` handle polygon points/rotation
- think about multiple selections
- hotkey to center camera on selected (and button)
- hotkey to release control (and swap back, and control selected)
- uncontrollable items (bounds)